### PR TITLE
Add space to the start of the env var export

### DIFF
--- a/aws-switchrole.py
+++ b/aws-switchrole.py
@@ -98,7 +98,7 @@ try:
   print_color(color.normal)
 
   for k, v in env_vars.iteritems():
-    print "export {}={}".format(k,v)
+    print " export {}={}".format(k,v)
 
 except:
   print_color(color.red)


### PR DESCRIPTION
Hi @hybby 

I think your script is really helpful, however I think it'd be better if shells didn't record the exported credentials. Most shells will not add this when there's a space in front of a command, what do you think?

Cheers
Andrew