### PR TITLE
Update regexp to allow dashes and underscores

### DIFF
--- a/aws-switchrole.py
+++ b/aws-switchrole.py
@@ -62,7 +62,8 @@ def print_info(text):
 # given a list of config sections, return ones that look like profiles
 def get_profiles(config_sections):
     profiles = []
-    profile_pattern = re.compile('^profile (\w+)$')
+    profile_re = r'^profile ([A-Za-z0-9_-]+)$'
+    profile_pattern = re.compile(profile_re)
 
     for section in config_sections:
         result = profile_pattern.search(section)
@@ -133,7 +134,7 @@ if __name__ == "__main__":
         role = config.get("profile {}".format(profile), "role_arn")
     except:
         print_error(
-            "FATAL: couldn't find profile '{}' in '{}'".format(
+            "FATAL: couldn't find a role_arn section in profile '{}'".format(
                 profile,
                 config_file
             )


### PR DESCRIPTION
# What?
Updates the regular expression that searches `~/.aws/config` to support an unlimited number of dashes and underscores, in any pattern.

Originally, I was going to write this regular expression a bit stricter to ensure that profiles didn't begin or end with dashes, or that they didn't contain two dashes in a row.  But that's probably not for me to validate.  I don't know offhand what AWS's restrictions on these names are, but `aws-cli` should take care of erroring if there's a problem.

Also updates a misleading error message.

Fixes #9.

# Testing?
Created this `~/.aws/config` file:

```
[default]
output = json
region = us-east-1

[profile drew]
region=us-east-1
output=text

[profile drew-test]
region=us-east-1
output=text

[profile drew--test]

[profile -drew-test]

[profile drew-test-]

[profile drew--test]

[profile drew-test-two]

[profile drew_test]

[profile drew_test_two]
```

Running the script shows the following:

```
$ ./aws-switchrole.py
please choose your profile:
  1. -drew-test
  2. drew
  3. drew--test
  4. drew-test
  5. drew-test-
  6. drew-test-two
  7. drew_test
  8. drew_test_two
```