### PR TITLE
Add copy to clipboard function, python3 support and allow for pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.requirements.txt
+aws_switchrole.egg-info/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+define HELP
+make requirements   - Install requirements in your virtualenv
+endef
+
+export HELP
+
+all help:
+	@echo "$$HELP"
+
+clean:
+	rm -rf .requirements.txt
+	find . -name '*.pyc' -delete
+
+requirements: .requirements.txt
+
+.requirements.txt: requirements.txt
+	pip install -r requirements.txt
+	pip freeze > $@
+
+release:
+	python setup.py sdist upload -r internal

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 define HELP
 make requirements   - Install requirements in your virtualenv
+make release      - Deploy package in internal PyPI (only if you have permission)
 endef
 
 export HELP

--- a/README.md
+++ b/README.md
@@ -64,6 +64,32 @@ PRs welcome and encouraged.
 
 Contributed code has to be compatible with python 2 and python 3
 
+
+# Publishing
+
+for my own benefit, mainly.
+
+make sure `~/.pypirc` is configured correctly for `pypitest` and `pypi`.
+
+tag your latest commit
+
+  ```
+  git tag -a 0.1 'release notes'
+  git push --tags
+  ```
+
+upload to the test pypi with
+
+  ```
+  python setup.py sdist upload -r pypitest
+  ```
+
+and the real one with
+
+  ```
+  python setup.py sdist upload -r pypi
+  ```
+
 ## Set up
 
 * `mkvirtualenv aws-switchrole`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ optionally the '--copy' option will copy the exports to the clipboard automatica
 
 
 # Installation
-  1. pip install aws-switchrole --extra-index-url https://localpypi.east.fdbox.net/simple/
+  1. pip install aws-switchrole
   2. ensure your `~/.aws/credentials` and `~/.aws/config` files are configured.  i use the latter for profiles:
 
   ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ paste 'em into your shell and you're good to go for a while.  creds last for
 one hour.  sadly we can't set up the environment from a child process, so copy
 and pasting into your environment will have to do.
 
+optionally the '--copy' option will cvopy the exports to the clipboard automatically
+
 
 ### installation
   1. clone this repo

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## aws-switchrole
+# aws-switchrole
 a script to generate temporary credentials for aws roles.
 
 use it if you need environment variablised credentials for use with tools
@@ -37,15 +37,9 @@ and pasting into your environment will have to do.
 optionally the '--copy' option will cvopy the exports to the clipboard automatically
 
 
-### installation
-  1. clone this repo
-  2. make sure you have [`aws-cli`](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) installed:
-
-  ```
-  pip install awscli --upgrade --user
-  ```
-
-  3. ensure your `~/.aws/credentials` and `~/.aws/config` files are configured.  i use the latter for profiles:
+# Installation
+  1. pip install aws-switchrole --extra-index-url https://localpypi.east.fdbox.net/simple/
+  2. ensure your `~/.aws/credentials` and `~/.aws/config` files are configured.  i use the latter for profiles:
 
   ```
   $ cat ~/.aws/credentials
@@ -64,12 +58,20 @@ optionally the '--copy' option will cvopy the exports to the clipboard automatic
   source_profile = default
   ```
 
-  3. set up an alias or symlink to the script.  for example:
+# Development
 
-  ```
-  # create a shell alias (remember to add to your dotfiles!)
-  alias aws-switchrole="${HOME}/git/aws-switchrole/aws-switchrole.py"
+PRs welcome and encouraged.
 
-  # or alternatively, symlink it to a place in your $PATH (i use `${HOME}/bin` for this)
-  ln -s ${HOME}/git/aws-switchrole/aws-switchrole.py ${HOME}/bin/aws-switchrole`
-  ```
+Contributed code has to be compatible with python 2 and python 3
+
+## Set up
+
+* `mkvirtualenv aws-switchrole`
+* `make requirements`
+
+
+## Simulating package install
+
+If you want to use the code as if it was installed in your virtualenv (for example to use the CLI tool while you develop):
+
+* `pip install --editable .` , where `.` is the path to the folder containing `setup.py`

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ paste 'em into your shell and you're good to go for a while.  creds last for
 one hour.  sadly we can't set up the environment from a child process, so copy
 and pasting into your environment will have to do.
 
-optionally the '--copy' option will cvopy the exports to the clipboard automatically
+optionally the '--copy' option will copy the exports to the clipboard automatically
 
 
 # Installation

--- a/aws_switchrole/aws_switchrole.py
+++ b/aws_switchrole/aws_switchrole.py
@@ -3,7 +3,10 @@
 # use it if you need environment variablised credentials for use with tools
 # that don't support role switching (looking at you apex and terraform).
 import os
-import ConfigParser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 import argparse
 import time
 import subprocess
@@ -11,6 +14,7 @@ import json
 import sys
 import re
 from distutils.spawn import find_executable
+import pyperclip
 
 
 # colors
@@ -33,7 +37,7 @@ def print_color(color):
 # red text and bomb out
 def print_error(text):
     print_color(color.red)
-    print text
+    print(text)
     print_color(color.normal)
     sys.exit(1)
 
@@ -41,21 +45,21 @@ def print_error(text):
 # yellow text
 def print_warning(text):
     print_color(color.yellow)
-    print text
+    print(text)
     print_color(color.normal)
 
 
 # green text
 def print_ok(text):
     print_color(color.green)
-    print text
+    print(text)
     print_color(color.normal)
 
 
 # blue text
 def print_info(text):
     print_color(color.blue)
-    print text
+    print(text)
     print_color(color.normal)
 
 
@@ -82,7 +86,7 @@ def get_profile_choice(profiles):
 
     if profiles:
         for profile in profiles:
-            print "  {}. {}".format((i + 1), profile)
+            print("  {}. {}".format((i + 1), profile))
             i += 1
     else:
         print_error(
@@ -91,7 +95,7 @@ def get_profile_choice(profiles):
 
     while not valid_choice:
         try:
-            choice = int(raw_input("-> "))
+            choice = int(input("-> "))
         except ValueError:
             choice = 0
 
@@ -105,7 +109,7 @@ def get_profile_choice(profiles):
 if __name__ == "__main__":
     # open our aws config file
     config_file = '~/.aws/config'
-    config = ConfigParser.RawConfigParser()
+    config = configparser.RawConfigParser()
     config.read(os.path.expanduser(config_file))
     profiles = get_profiles(config.sections())
 
@@ -127,6 +131,13 @@ if __name__ == "__main__":
         required=False,
         default=3600,
         help='time in seconds that sts credentials should last'
+    )
+
+    parser.add_argument(
+        '--copy',
+        action='append_const',
+        const=True,
+        help='copy export command to clipboard'
     )
 
     args = parser.parse_args()
@@ -166,13 +177,14 @@ if __name__ == "__main__":
 
     # load the json response into a dict
     try:
-        creds = json.loads(out)
+        creds = json.loads(out.decode('utf-8'))
+        print(creds)
     except:
         print_warning('problem parsing AWS response. STDOUT and STDERR below:')
         print_warning('STDOUT:')
-        print out
+        print(out)
         print_warning('STDERR:')
-        print err
+        print(err)
         sys.exit(1)
 
     # print out our returned values as export commands, ready to go.
@@ -189,14 +201,21 @@ if __name__ == "__main__":
             "---- load these vars into your env to assume profile's role ----"
         )
 
-        for k, v in env_vars.iteritems():
-            print " export {}={}".format(k, v)
+        stuff_to_copy=[]
+        for k, v in env_vars.items():
+            cmd = "export {}={}".format(k, v)
+            print('{}'.format(cmd))
+            stuff_to_copy.append(cmd)
+
+        if args.copy:
+            pyperclip.copy("\n".join(stuff_to_copy) + '\n')
 
         print_info(
             '----------------------------------------------------------------'
         )
 
+
     except:
         print_error('AWS response did not contain expected valuess. dumping:')
-        print creds
+        print(creds)
         sys.exit(1)

--- a/aws_switchrole/aws_switchrole.py
+++ b/aws_switchrole/aws_switchrole.py
@@ -178,7 +178,6 @@ if __name__ == "__main__":
     # load the json response into a dict
     try:
         creds = json.loads(out.decode('utf-8'))
-        print(creds)
     except:
         print_warning('problem parsing AWS response. STDOUT and STDERR below:')
         print_warning('STDOUT:')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+awscli>=1.15.25
+pyperclip>=1.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,18 @@
 from setuptools import find_packages, setup
-import sys
-
-
-kw = {}
 
 setup(
-    name='aws-switchrolel',
-    version='0.1',
-    author='hybby',
-    author_email='dev@fanduel.com',
-    url='https://github.com/hybby/aws-switchrole',
-    description='aws-switchrole',
-    packages=find_packages(),
-    install_requires=[
+    name = 'aws-switchrole',
+    packages = find_packages(),
+    version = '0.1',
+    description = 'a tool to allow you to switch AWS roles on your console',
+    author = 'hybby',
+    author_email = 'iamdrew@gmail.com',
+    url = 'https://github.com/hybby/aws-switchrole',
+    download_url = 'https://github.com/hybby/aws-switchrole/archive/0.1.tar.gz',
+    keywords = ['aws', 'iam', 'sts'],
+    install_requires = [
         'awscli>=1.15.25',
         'pyperclip>=1.6.0',
     ],
-    include_package_data=True,
-    entry_points='''
-        [console_scripts]
-        aws-switchrole=aws_switchrole.aws_switchrole:main
-    ''',
-    **kw
+    classifiers = [],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import find_packages, setup
 setup(
     name = 'aws-switchrole',
     packages = find_packages(),
-    version = '0.1',
+    version = '0.2',
     description = 'a tool to allow you to switch AWS roles on your console',
     author = 'hybby',
     author_email = 'iamdrew@gmail.com',
     url = 'https://github.com/hybby/aws-switchrole',
-    download_url = 'https://github.com/hybby/aws-switchrole/archive/0.1.tar.gz',
+    download_url = 'https://github.com/hybby/aws-switchrole/archive/0.2.tar.gz',
     keywords = ['aws', 'iam', 'sts'],
     install_requires = [
         'awscli>=1.15.25',

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import find_packages, setup
 setup(
     name = 'aws-switchrole',
     packages = find_packages(),
-    version = '0.2',
+    version = '0.0.1',
     description = 'a tool to allow you to switch AWS roles on your console',
     author = 'hybby',
     author_email = 'iamdrew@gmail.com',
     url = 'https://github.com/hybby/aws-switchrole',
-    download_url = 'https://github.com/hybby/aws-switchrole/archive/0.2.tar.gz',
+    download_url = 'https://github.com/hybby/aws-switchrole/archive/0.0.1.tar.gz',
     keywords = ['aws', 'iam', 'sts'],
     install_requires = [
         'awscli>=1.15.25',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import find_packages, setup
+import sys
+
+
+kw = {}
+
+setup(
+    name='aws-switchrolel',
+    version='0.1',
+    author='hybby',
+    author_email='dev@fanduel.com',
+    url='https://github.com/hybby/aws-switchrole',
+    description='aws-switchrole',
+    packages=find_packages(),
+    install_requires=[
+        'awscli>=1.15.25',
+        'pyperclip>=1.6.0',
+    ],
+    include_package_data=True,
+    entry_points='''
+        [console_scripts]
+        aws-switchrole=aws_switchrole.aws_switchrole:main
+    ''',
+    **kw
+)


### PR DESCRIPTION
Adds a --copy function which copies the export command to clipboard
Add makefile for installing requirements
Adds python3 support
Adds setup, this allows for aws-switchrole to be installed via pip