### PR TITLE
Fix `pip` entrypoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,19 @@ from setuptools import find_packages, setup
 setup(
     name = 'aws-switchrole',
     packages = find_packages(),
-    version = '0.0.1',
+    version = '0.0.2',
     description = 'a tool to allow you to switch AWS roles on your console',
     author = 'hybby',
     author_email = 'iamdrew@gmail.com',
     url = 'https://github.com/hybby/aws-switchrole',
-    download_url = 'https://github.com/hybby/aws-switchrole/archive/0.0.1.tar.gz',
+    download_url = 'https://github.com/hybby/aws-switchrole/archive/0.0.2.tar.gz',
     keywords = ['aws', 'iam', 'sts'],
     install_requires = [
         'awscli>=1.15.25',
         'pyperclip>=1.6.0',
     ],
+    entry_points={
+        'console_scripts': [ 'aws-switchrole=aws_switchrole.aws_switchrole:main' ]
+    },
     classifiers = [],
 )


### PR DESCRIPTION
Thanks to @martinwarby for bringing to my attention that Pip installs were broken and for his help on identifying how to configure `setup.py` correctly.

If you installed this before and found it was broken, run this:

```
pip install aws-switchrole --upgrade
```

And you should be cooking with gas again.